### PR TITLE
Cleanup and error flow refactor (PR 1 of 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ go test ./internal/app -run TestWriteConfig
 ./esp --verbose <subcommand>
 ```
 
-`AWS_DEFAULT_REGION` and `AWS_PROFILE` must be set before invoking any subcommand — `cmd/root.go`'s `initConfig` (run via `cobra.OnInitialize`) exits with non-zero status (1 and 2 respectively) if either is missing. They are NOT required for `esp --help` (cobra short-circuits before `initConfig`) or for `go test ./...`.
+`AWS_DEFAULT_REGION` and `AWS_PROFILE` must be set before invoking any subcommand — `cmd/root.go`'s `persistentPreRun` (wired as `rootCmd.PersistentPreRunE`) returns an error if either is missing, which cobra surfaces as `Error: <message>` on stderr; `Execute()` then exits 1. (Previously, missing env vars exited 1 or 2 directly via `os.Exit`; the codes now collapse to a uniform 1.) They are NOT required for `esp --help` (cobra short-circuits before `PersistentPreRunE`) or for `go test ./...`.
 
 ## Architecture
 
@@ -33,7 +33,7 @@ The code is organized in three layers:
 
 1. **`cmd/`** — Cobra subcommands (`get`, `list`/`ls`, `put`/`add`/`create`, `delete`/`rm`, `copy`/`cp`, `move`/`mv`, `init`, `version`). Each file registers itself onto `rootCmd` via `init()`. The package-level globals `esp *app.Config` and `c *client.EspClient` (in `cmd/root.go`) are constructed once in `root.go`'s `init()` and used by every subcommand.
 
-2. **`internal/client/`** — A thin facade over a backend `Client` interface (`Save`, `GetOne`, `GetMany`, `Copy`, `Delete`). `client.New` switches on `Config.Backend`; today the only valid value is `"ssm"` and any other value panics. Add new backends here.
+2. **`internal/client/`** — A thin facade over a backend `Client` interface (`Save`, `GetOne`, `GetMany`, `Copy`, `Delete`); each method returns `(value, error)`. `client.New` switches on `Config.Backend`; today the only valid value is `"ssm"`, and any other value returns `fmt.Errorf("unsupported backend %q", c.Backend)`. Add new backends here.
 
 3. **`internal/ssm/`** — The AWS SSM implementation of the `Client` interface, plus parameter-type conversion (`utils.go`) and AWS-error mapping (`errors.go`).
 

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -27,7 +27,10 @@ var copyCmd = &cobra.Command{
 			Source:     args[0],
 			Destination: args[1],
 		}
-		c.Copy(cc)
+		if _, err := c.Copy(cc); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 	},
 	Example: "esp cp /ssm/path/key /ssm/new/path/key",
 }

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1,36 +1,35 @@
 package cmd
 
 import (
-	"fmt"
+	"errors"
+
 	"github.com/pinpt/esp/internal/common"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // cpCmd represents the cp command
 var copyCmd = &cobra.Command{
-	Use:   "copy [OPTIONS] SRC_SSM_PATH DEST_SSM_PATH",
+	Use:     "copy [OPTIONS] SRC_SSM_PATH DEST_SSM_PATH",
 	Aliases: []string{"cp"},
-	Short: "Copy a SSM Param from its current path to a new SSM Path",
-	Long: "Copy SSM value from an existing path to a new path.\n",
-	Args: cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	Short:   "Copy a SSM Param from its current path to a new SSM Path",
+	Long:    "Copy SSM value from an existing path to a new path.\n",
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		if args[0] == "" {
-			fmt.Fprintln(os.Stderr, "source can not be empty")
-			os.Exit(1)
+			return errors.New("source can not be empty")
 		}
 		if args[1] == "" {
-			fmt.Fprintln(os.Stderr, "destination can not be empty")
-			os.Exit(1)
+			return errors.New("destination can not be empty")
 		}
 		cc := common.CopyCommand{
-			Source:     args[0],
+			Source:      args[0],
 			Destination: args[1],
 		}
 		if _, err := c.Copy(cc); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return err
 		}
+		return nil
 	},
 	Example: "esp cp /ssm/path/key /ssm/new/path/key",
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/logrusorgru/aurora/v4"
 	"github.com/pinpt/esp/internal/common"
 	"github.com/spf13/cobra"
@@ -15,9 +17,13 @@ var deleteCmd = &cobra.Command{
 	Long:  `Allows you to delete a specific ssm parameter with an exact path.`,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		param := c.Delete(common.DeleteInput{
+		param, err := c.Delete(common.DeleteInput{
 			Name:    args[0],
 		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 		name := aurora.BrightYellow(param)
 		fmt.Printf("Deleted: %s\n", name)
 	},

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/logrusorgru/aurora/v4"
 	"github.com/pinpt/esp/internal/common"
@@ -11,21 +10,22 @@ import (
 
 // deleteCmd gets the parameter from the backend store
 var deleteCmd = &cobra.Command{
-	Use:   "delete [path]",
+	Use:     "delete [path]",
 	Aliases: []string{"rm"},
-	Short: "Delete a parameter by path in SSM",
-	Long:  `Allows you to delete a specific ssm parameter with an exact path.`,
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Short:   "Delete a parameter by path in SSM",
+	Long:    `Allows you to delete a specific ssm parameter with an exact path.`,
+	Args:    cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		param, err := c.Delete(common.DeleteInput{
-			Name:    args[0],
+			Name: args[0],
 		})
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return err
 		}
 		name := aurora.BrightYellow(param)
 		fmt.Printf("Deleted: %s\n", name)
+		return nil
 	},
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -62,10 +62,14 @@ var getCmd = &cobra.Command{
 		decrypt, _ := cmd.Flags().GetBool("decrypt")
 		details, _ := cmd.Flags().GetBool("details")
 
-		param := c.GetParam(common.GetOneInput{
+		param, err := c.GetParam(common.GetOneInput{
 			Name:    getParamPath(args[0]),
 			Decrypt: decrypt,
 		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 		display(param, details)
 	},
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -58,7 +58,8 @@ var getCmd = &cobra.Command{
 	Short: "Query path for SSM",
 	Long:  `Allows you to get a specific ssm parameter with an exact path or recursively get params.`,
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		decrypt, _ := cmd.Flags().GetBool("decrypt")
 		details, _ := cmd.Flags().GetBool("details")
 
@@ -67,10 +68,10 @@ var getCmd = &cobra.Command{
 			Decrypt: decrypt,
 		})
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return err
 		}
 		display(param, details)
+		return nil
 	},
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -9,12 +9,14 @@ func initCmd() *cobra.Command {
 	var initCmd = &cobra.Command{
 		Use:   "init",
 		Short: "Initializes the current directory to be an ESP based application.",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			esp.InitQuestions()
+			return nil
 		},
 	}
 
-	return  initCmd
+	return initCmd
 }
 
 func init() {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pinpt/esp/internal/client"
 	"github.com/pinpt/esp/internal/common"
@@ -25,7 +24,7 @@ func getPath(a []string) string {
 	return a[0]
 }
 
-func listParams(cmd *cobra.Command, c *client.EspClient, path string) {
+func listParams(cmd *cobra.Command, c *client.EspClient, path string) error {
 	decrypt, _ := cmd.Flags().GetBool("decrypt")
 	params, err := c.ListParams(common.ListParamInput{
 		Path:      path,
@@ -33,10 +32,10 @@ func listParams(cmd *cobra.Command, c *client.EspClient, path string) {
 		Recursive: true,
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return err
 	}
 	displayParams(params)
+	return nil
 }
 
 // listCmd represents the list command
@@ -45,11 +44,12 @@ func listCmd() *cobra.Command {
 		Use:     "list [path]",
 		Aliases: []string{"ls"},
 		Short:   "Recursively list a SSM path if given.",
-		Long:    `The list command gives you an easy way to recursively get all SSM parameters with a base path.
+		Long: `The list command gives you an easy way to recursively get all SSM parameters with a base path.
 If you have a .espFile.yaml in the current directory this command will list all params under the project path.`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			path := getPath(args)
-			listParams(cmd, c, path)
+			return listParams(cmd, c, path)
 		},
 	}
 	return listCmd

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/pinpt/esp/internal/client"
 	"github.com/pinpt/esp/internal/common"
 
@@ -23,13 +25,17 @@ func getPath(a []string) string {
 	return a[0]
 }
 
-func listParams(cmd *cobra.Command, c *client.EspClient, path string)  {
+func listParams(cmd *cobra.Command, c *client.EspClient, path string) {
 	decrypt, _ := cmd.Flags().GetBool("decrypt")
-	params := c.ListParams(common.ListParamInput{
+	params, err := c.ListParams(common.ListParamInput{
 		Path:      path,
 		Decrypt:   decrypt,
 		Recursive: true,
 	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	displayParams(params)
 }
 

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/logrusorgru/aurora/v4"
 	"github.com/pinpt/esp/internal/common"
@@ -16,18 +15,19 @@ var moveCmd = &cobra.Command{
 	Short:   "move a parameter by path in SSM",
 	Long:    `Allows you to move a specific ssm parameter with an exact path.`,
 	Args:    cobra.MinimumNArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		p, err := c.Move(common.MoveCommand{
 			Source:      args[0],
 			Destination: args[1],
 		})
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return err
 		}
 		src := aurora.BrightYellow(p.Source)
 		dest := aurora.BrightYellow(p.Destination)
 		fmt.Printf("%s => %s\n", src, dest)
+		return nil
 	},
 }
 

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/logrusorgru/aurora/v4"
 	"github.com/pinpt/esp/internal/common"
@@ -16,10 +17,14 @@ var moveCmd = &cobra.Command{
 	Long:    `Allows you to move a specific ssm parameter with an exact path.`,
 	Args:    cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		p := c.Move(common.MoveCommand{
+		p, err := c.Move(common.MoveCommand{
 			Source:      args[0],
 			Destination: args[1],
 		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 		src := aurora.BrightYellow(p.Source)
 		dest := aurora.BrightYellow(p.Destination)
 		fmt.Printf("%s => %s\n", src, dest)

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/pinpt/esp/internal/common"
@@ -39,24 +38,24 @@ func buildEspParamInputFromCmd(cmd *cobra.Command) common.EspParamInput {
 
 // putCmd stores the parameter in the backend store
 var putCmd = &cobra.Command{
-	Use:   "put",
+	Use:     "put",
 	Aliases: []string{"add", "create"},
-	Short: "Creates an SSM parameter with the given value.",
-	Long: `Simple command to add values to SSM parameter store.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Short:   "Creates an SSM parameter with the given value.",
+	Long:    `Simple command to add values to SSM parameter store.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		param := buildEspParamInputFromCmd(cmd)
 		if _, err := c.Save(param); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return err
 		}
 		savedParam, err := c.GetParam(common.GetOneInput{
 			Name: param.Name,
 		})
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return err
 		}
 		detailDisplay(savedParam)
+		return nil
 	},
 }
 

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/pinpt/esp/internal/common"
+	"os"
 	"strings"
 
+	"github.com/pinpt/esp/internal/common"
 	"github.com/spf13/cobra"
 )
 
@@ -44,10 +45,17 @@ var putCmd = &cobra.Command{
 	Long: `Simple command to add values to SSM parameter store.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		param := buildEspParamInputFromCmd(cmd)
-		c.Save(param)
-		savedParam := c.GetParam(common.GetOneInput{
+		if _, err := c.Save(param); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		savedParam, err := c.GetParam(common.GetOneInput{
 			Name: param.Name,
 		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 		detailDisplay(savedParam)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,7 +61,12 @@ func initConfig() {
 		os.Exit(2)
 	}
 
-	c = client.New(esp)
+	var err error
+	c, err = client.New(esp)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	viper.SetConfigName(esp.Filename)
 	viper.AddConfigPath(esp.Path)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,6 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }
@@ -34,7 +33,8 @@ func init() {
 	esp = app.New(false)
 	// setting this to SSM just to make the interface nicer, since we only have the SSM backend
 	esp.Backend = "ssm"
-	cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(configureLogging)
+	rootCmd.PersistentPreRunE = persistentPreRun
 
 	// CLI args
 	rootCmd.PersistentFlags().StringVarP(&esp.Env, "env", "e", "", "Declare the env to work on.")
@@ -42,30 +42,34 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Show more output")
 }
 
-// initConfig reads in config file and ENV variables if set.
-// Runs via cobra.OnInitialize before any subcommand executes; not invoked
-// for --help, so help output works without AWS credentials.
-func initConfig() {
+// configureLogging sets the slog default handler. No I/O, no failure
+// path. Runs via cobra.OnInitialize, which is skipped for --help.
+func configureLogging() {
 	level := slog.LevelWarn
 	if verbose {
 		level = slog.LevelInfo
 	}
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+}
+
+// persistentPreRun validates AWS env vars, constructs the backend
+// client, reads the .espFile, and (when one is present) marks --env
+// required. Cobra short-circuits before PersistentPreRunE for --help,
+// so help output still works without AWS credentials.
+func persistentPreRun(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 
 	if _, ok := os.LookupEnv("AWS_DEFAULT_REGION"); !ok {
-		fmt.Println("Please set the AWS_DEFAULT_REGION environment variable.")
-		os.Exit(1)
+		return fmt.Errorf("AWS_DEFAULT_REGION environment variable is not set")
 	}
 	if _, ok := os.LookupEnv("AWS_PROFILE"); !ok {
-		fmt.Println("Please set the AWS_PROFILE environment variable.")
-		os.Exit(2)
+		return fmt.Errorf("AWS_PROFILE environment variable is not set")
 	}
 
 	var err error
 	c, err = client.New(esp)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 
 	viper.SetConfigName(esp.Filename)
@@ -78,16 +82,11 @@ func initConfig() {
 
 	if esp.IsEspProject {
 		if err := viper.Unmarshal(&esp); err != nil {
-			fmt.Printf("Error parsing the %s\n", esp.Filename)
+			return fmt.Errorf("parsing %s: %w", esp.Filename, err)
 		}
-		// not going to force this at the moment.  I will add this when I have a second backend
-		/*if err := rootCmd.MarkFlagRequired("backend"); err != nil {
-			//fmt.Printf("There is an %s.yaml defined, so you need to set --env arg.\n", esp.Filename)
-			os.Exit(3)
-		}*/
 		if err := rootCmd.MarkFlagRequired("env"); err != nil {
-			//fmt.Printf("There is an %s.yaml defined, so you need to set --env arg.\n", esp.Filename)
-			os.Exit(3)
+			return fmt.Errorf("marking --env required: %w", err)
 		}
 	}
+	return nil
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,8 +10,10 @@ import (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Version of esp",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		fmt.Println("ESP version 0.2.0")
+		return nil
 	},
 }
 

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -62,7 +62,3 @@ func (c *Config) InitQuestions() {
 		fmt.Printf("Error writing file: %s", err)
 	}
 }
-
-func (c *Config) setPrefixes() {
-
-}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,11 +10,11 @@ import (
 
 // Client the main interface that is defined by the backend implementation.
 type Client interface {
-	Save(p common.EspParamInput) common.SaveOutput
-	GetOne(p common.GetOneInput) common.EspParam
-	GetMany(p common.ListParamInput) []common.EspParam
-	Copy(cc common.CopyCommand) common.SaveOutput
-	Delete(p common.DeleteInput) string
+	Save(p common.EspParamInput) (common.SaveOutput, error)
+	GetOne(p common.GetOneInput) (common.EspParam, error)
+	GetMany(p common.ListParamInput) ([]common.EspParam, error)
+	Copy(cc common.CopyCommand) (common.SaveOutput, error)
+	Delete(p common.DeleteInput) (string, error)
 }
 
 // EspClient is the main struct for interacting with the backend driver
@@ -29,7 +29,9 @@ func New(c *app.Config) (*EspClient, error) {
 		return nil, fmt.Errorf("unsupported backend %q", c.Backend)
 	}
 	svc := ssm.New()
-	svc.Init()
+	if err := svc.Init(); err != nil {
+		return nil, err
+	}
 	return &EspClient{
 		Backend: c.Backend,
 		Client:  svc,
@@ -37,7 +39,7 @@ func New(c *app.Config) (*EspClient, error) {
 }
 
 // GetParam Queries the ssm param
-func (c *EspClient) GetParam(i common.GetOneInput) common.EspParam {
+func (c *EspClient) GetParam(i common.GetOneInput) (common.EspParam, error) {
 	in := common.GetOneInput{
 		Name:    i.Name,
 		Decrypt: i.Decrypt,
@@ -46,23 +48,25 @@ func (c *EspClient) GetParam(i common.GetOneInput) common.EspParam {
 }
 
 // ListParams takes a path and returns all of the parameters under it
-func (c *EspClient) ListParams(p common.ListParamInput) []common.EspParam {
+func (c *EspClient) ListParams(p common.ListParamInput) ([]common.EspParam, error) {
 	return c.Client.GetMany(p)
 }
 
 // Save stores the parameter in the configured backend
-func (c *EspClient) Save(p common.EspParamInput) common.SaveOutput {
+func (c *EspClient) Save(p common.EspParamInput) (common.SaveOutput, error) {
 	return c.Client.Save(p)
 }
 
 // Delete removes a parameter from the backend
-func (c *EspClient) Delete(p common.DeleteInput) string {
+func (c *EspClient) Delete(p common.DeleteInput) (string, error) {
 	return c.Client.Delete(p)
 }
 
 // Copy allows you to copy one path to another
-func (c *EspClient) Copy(cc common.CopyCommand) common.EspParam {
-	_ = c.Client.Copy(cc)
+func (c *EspClient) Copy(cc common.CopyCommand) (common.EspParam, error) {
+	if _, err := c.Client.Copy(cc); err != nil {
+		return common.EspParam{}, err
+	}
 
 	query := common.GetOneInput{
 		Name:    cc.Destination,
@@ -72,18 +76,25 @@ func (c *EspClient) Copy(cc common.CopyCommand) common.EspParam {
 }
 
 // Move copies a single param to a new path in the backend
-func (c *EspClient) Move(mc common.MoveCommand) common.MoveCommand {
-	p := c.GetParam(common.GetOneInput{
+func (c *EspClient) Move(mc common.MoveCommand) (common.MoveCommand, error) {
+	p, err := c.GetParam(common.GetOneInput{
 		Name:    mc.Source,
 		Decrypt: true,
 	})
+	if err != nil {
+		return mc, err
+	}
 
-	_ = c.Save(common.EspParamInput{
+	if _, err := c.Save(common.EspParamInput{
 		Name:   mc.Destination,
 		Secure: p.Secure,
 		Value:  p.Value,
-	})
+	}); err != nil {
+		return mc, err
+	}
 
-	_ = c.Delete(common.DeleteInput{Name: mc.Source})
-	return mc
+	if _, err := c.Delete(common.DeleteInput{Name: mc.Source}); err != nil {
+		return mc, err
+	}
+	return mc, nil
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"fmt"
+
 	"github.com/pinpt/esp/internal/app"
 	"github.com/pinpt/esp/internal/common"
 	"github.com/pinpt/esp/internal/ssm"
@@ -22,17 +24,16 @@ type EspClient struct {
 }
 
 // New creates a new instance of the Client for esp
-func New(c *app.Config) *EspClient {
-	if c.Backend == "ssm" {
-		svc := ssm.New()
-		svc.Init()
-		return &EspClient{
-			Backend: c.Backend,
-			Client: svc,
-		}
-	} else {
-		panic("Currently only the ssm backend is valid.")
+func New(c *app.Config) (*EspClient, error) {
+	if c.Backend != "ssm" {
+		return nil, fmt.Errorf("unsupported backend %q", c.Backend)
 	}
+	svc := ssm.New()
+	svc.Init()
+	return &EspClient{
+		Backend: c.Backend,
+		Client:  svc,
+	}, nil
 }
 
 // GetParam Queries the ssm param

--- a/internal/ssm/ssm.go
+++ b/internal/ssm/ssm.go
@@ -2,8 +2,6 @@ package ssm
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -30,8 +28,18 @@ type Service struct {
 	Cfg    aws.Config
 }
 
+// mapErr applies the per-action error mapper. If the mapper returns
+// nil (the error wasn't a recognized AWS error type), return the raw
+// error so the caller still sees the failure.
+func mapErr(a action, err error) error {
+	if mapped := checkSSMError(a, err); mapped != nil {
+		return mapped
+	}
+	return err
+}
+
 // Save a single param for a given path
-func (s *Service) Save(p common.EspParamInput) common.SaveOutput {
+func (s *Service) Save(p common.EspParamInput) (common.SaveOutput, error) {
 	pi := &awsssm.PutParameterInput{
 		Type:  selectType(p.Secure),
 		Name:  aws.String(p.Name),
@@ -39,38 +47,38 @@ func (s *Service) Save(p common.EspParamInput) common.SaveOutput {
 	}
 	param, err := s.Svc.PutParameter(context.Background(), pi)
 	if err != nil {
-		handleAwsErr(Save, err)
+		return common.SaveOutput{}, mapErr(Save, err)
 	}
-	return common.SaveOutput{Version: param.Version}
+	return common.SaveOutput{Version: param.Version}, nil
 }
 
 // Delete a single param for a given path
-func (s *Service) Delete(p common.DeleteInput) string {
+func (s *Service) Delete(p common.DeleteInput) (string, error) {
 	dpi := &awsssm.DeleteParameterInput{
 		Name: aws.String(p.Name),
 	}
 	_, err := s.Svc.DeleteParameter(context.Background(), dpi)
 	if err != nil {
-		handleAwsErr(Delete, err)
+		return "", mapErr(Delete, err)
 	}
-	return p.Name
+	return p.Name, nil
 }
 
 // GetOne gets a single param for a given path
-func (s *Service) GetOne(p common.GetOneInput) common.EspParam {
+func (s *Service) GetOne(p common.GetOneInput) (common.EspParam, error) {
 	si := &awsssm.GetParameterInput{
 		Name:           aws.String(p.Name),
 		WithDecryption: aws.Bool(p.Decrypt),
 	}
 	resp, err := s.Svc.GetParameter(context.Background(), si)
 	if err != nil {
-		handleAwsErr(Get, err)
+		return common.EspParam{}, mapErr(Get, err)
 	}
-	return convertToEspParam(*resp.Parameter)
+	return convertToEspParam(*resp.Parameter), nil
 }
 
 // GetMany recursively gets parameters from a given path
-func (s *Service) GetMany(p common.ListParamInput) []common.EspParam {
+func (s *Service) GetMany(p common.ListParamInput) ([]common.EspParam, error) {
 	si := &awsssm.GetParametersByPathInput{
 		Path:           aws.String(p.Path),
 		WithDecryption: aws.Bool(p.Decrypt),
@@ -78,7 +86,7 @@ func (s *Service) GetMany(p common.ListParamInput) []common.EspParam {
 	}
 	params, err := s.Svc.GetParametersByPath(context.Background(), si)
 	if err != nil {
-		handleAwsErr(GetMany, err)
+		return nil, mapErr(GetMany, err)
 	}
 
 	var espParams []common.EspParam
@@ -88,17 +96,20 @@ func (s *Service) GetMany(p common.ListParamInput) []common.EspParam {
 
 	if params.NextToken != nil {
 		si.NextToken = params.NextToken
-		moreParams := s.getNextParams(si)
+		moreParams, err := s.getNextParams(si)
+		if err != nil {
+			return nil, err
+		}
 		espParams = append(espParams, moreParams...)
 	}
-	return espParams
+	return espParams, nil
 }
 
 // getNextParams uses the NextToken to get more params
-func (s *Service) getNextParams(pi *awsssm.GetParametersByPathInput) []common.EspParam {
+func (s *Service) getNextParams(pi *awsssm.GetParametersByPathInput) ([]common.EspParam, error) {
 	params, err := s.Svc.GetParametersByPath(context.Background(), pi)
 	if err != nil {
-		handleAwsErr(GetMany, err)
+		return nil, mapErr(GetMany, err)
 	}
 
 	var espParams []common.EspParam
@@ -108,19 +119,25 @@ func (s *Service) getNextParams(pi *awsssm.GetParametersByPathInput) []common.Es
 
 	if params.NextToken != nil {
 		pi.NextToken = params.NextToken
-		moreParams := s.getNextParams(pi)
+		moreParams, err := s.getNextParams(pi)
+		if err != nil {
+			return nil, err
+		}
 		espParams = append(espParams, moreParams...)
 	}
-	return espParams
+	return espParams, nil
 }
 
 // Copy method copies the given parameter to a new location
-func (s *Service) Copy(cc common.CopyCommand) common.SaveOutput {
+func (s *Service) Copy(cc common.CopyCommand) (common.SaveOutput, error) {
 	input := common.GetOneInput{
 		Name:    cc.Source,
 		Decrypt: true,
 	}
-	sparam := s.GetOne(input)
+	sparam, err := s.GetOne(input)
+	if err != nil {
+		return common.SaveOutput{}, err
+	}
 
 	dparam := common.EspParamInput{
 		Name:   cc.Destination,
@@ -138,12 +155,12 @@ func New() *Service {
 }
 
 // Init create the actual session to talk to the AWS API
-func (s *Service) Init() {
+func (s *Service) Init() error {
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(s.Region))
 	if err != nil {
-		fmt.Printf("AWS config load error: %s\n", err.Error())
-		os.Exit(1)
+		return err
 	}
 	s.Cfg = cfg
 	s.Svc = awsssm.NewFromConfig(cfg)
+	return nil
 }

--- a/internal/ssm/ssm.go
+++ b/internal/ssm/ssm.go
@@ -84,46 +84,17 @@ func (s *Service) GetMany(p common.ListParamInput) ([]common.EspParam, error) {
 		WithDecryption: aws.Bool(p.Decrypt),
 		Recursive:      aws.Bool(p.Recursive),
 	}
-	params, err := s.Svc.GetParametersByPath(context.Background(), si)
-	if err != nil {
-		return nil, mapErr(GetMany, err)
-	}
+	paginator := awsssm.NewGetParametersByPathPaginator(s.Svc, si)
 
 	var espParams []common.EspParam
-	for _, v := range params.Parameters {
-		espParams = append(espParams, convertToEspParam(v))
-	}
-
-	if params.NextToken != nil {
-		si.NextToken = params.NextToken
-		moreParams, err := s.getNextParams(si)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.Background())
 		if err != nil {
-			return nil, err
+			return nil, mapErr(GetMany, err)
 		}
-		espParams = append(espParams, moreParams...)
-	}
-	return espParams, nil
-}
-
-// getNextParams uses the NextToken to get more params
-func (s *Service) getNextParams(pi *awsssm.GetParametersByPathInput) ([]common.EspParam, error) {
-	params, err := s.Svc.GetParametersByPath(context.Background(), pi)
-	if err != nil {
-		return nil, mapErr(GetMany, err)
-	}
-
-	var espParams []common.EspParam
-	for _, v := range params.Parameters {
-		espParams = append(espParams, convertToEspParam(v))
-	}
-
-	if params.NextToken != nil {
-		pi.NextToken = params.NextToken
-		moreParams, err := s.getNextParams(pi)
-		if err != nil {
-			return nil, err
+		for _, v := range page.Parameters {
+			espParams = append(espParams, convertToEspParam(v))
 		}
-		espParams = append(espParams, moreParams...)
 	}
 	return espParams, nil
 }

--- a/internal/ssm/utils.go
+++ b/internal/ssm/utils.go
@@ -1,9 +1,6 @@
 package ssm
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/pinpt/esp/internal/common"
@@ -30,13 +27,4 @@ func convertToEspParam(ap ssmtypes.Parameter) common.EspParam {
 		param.Secure = true
 	}
 	return param
-}
-
-// handleAwsErr it will for all of the AWS API errors and exit if exists
-func handleAwsErr(a action, err error) {
-	awsErr := checkSSMError(a, err)
-	if awsErr != nil {
-		fmt.Printf("SSM Error: %s\n", awsErr.Error())
-		os.Exit(1)
-	}
 }

--- a/internal/ssm/utils.go
+++ b/internal/ssm/utils.go
@@ -1,7 +1,6 @@
 package ssm
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -9,34 +8,6 @@ import (
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/pinpt/esp/internal/common"
 )
-
-// ParamType sets the base type for SSM parameter types
-type ParamType string
-
-// Defines the SSM types
-const (
-	String       ParamType = "string"
-	SecureString ParamType = "SecureString"
-	StringList   ParamType = "Stringlist"
-)
-
-// AwsParam represents an individual SSM parameter
-type AwsParam struct {
-	Arn              string
-	Name             string
-	Type             ParamType
-	Value            string
-	Version          int
-	LastModifiedDate float32
-}
-
-func (p *AwsParam) isValid() error {
-	switch p.Type {
-	case String, SecureString, StringList:
-		return nil
-	}
-	return errors.New("invalid SSM Parameter Type")
-}
 
 func selectType(t bool) ssmtypes.ParameterType {
 	if t {


### PR DESCRIPTION
## Summary

Implements PR 1 of the cleanup-and-tests design (`docs/superpowers/specs/2026-05-05-cleanup-and-tests-design.md`). Removes dead code and migrates the codebase from ad-hoc `os.Exit` / `panic` error handling to idiomatic cobra error flow. PR 2 (pure-logic tests) follows after this merges.

## Commits (in order)

1. `chore: remove dead code (AwsParam, setPrefixes)` — drops unreferenced struct, method, and supporting `ParamType` constants.
2. `refactor: client.New returns error instead of panic` — unsupported backend now returns `fmt.Errorf("unsupported backend %q", c.Backend)`.
3. `refactor: ssm methods return errors; remove handleAwsErr` — `Init` / `Save` / `GetOne` / `GetMany` / `Copy` / `Delete` all return `(value, error)`. Adds `mapErr` helper that falls back to the raw error when the AWS-error mapper returns nil (was previously a silent-swallow bug). `client.Client` interface updated to match.
4. `refactor: cmd subcommands use RunE with SilenceUsage` — every subcommand flips `Run` → `RunE`, sets `cmd.SilenceUsage = true` as the first line, and propagates errors via `return err`. The args-empty checks in `cmd/copy.go` become `errors.New(...)` per the bug-audit note.
5. `refactor: env-var validation moves to PersistentPreRunE` — `AWS_DEFAULT_REGION` / `AWS_PROFILE` checks, `client.New` construction, `viper.ReadInConfig`, and `MarkFlagRequired("env")` move into `rootCmd.PersistentPreRunE`. `slog` config stays in `cobra.OnInitialize`. `Execute()` exits 1 on any error.
6. `refactor: use ssm paginator for GetParametersByPath` — replaces the recursive `getNextParams` with `awsssm.NewGetParametersByPathPaginator` and the standard `for paginator.HasMorePages()` loop.
7. `chore: update CLAUDE.md error-flow notes` — reflects the `PersistentPreRunE` flow, the `(value, error)` interface, and the exit-code collapse.

## External behavior changes (per spec)

- Exit code on missing `AWS_DEFAULT_REGION` / `AWS_PROFILE` collapses from `1` / `2` to a uniform `1`. `MarkFlagRequired` failure also collapses from `3` to `1`. (These codes were undocumented and look incidental.)
- Cobra now prefixes errors with `Error:` on stderr, replacing the bare `fmt.Println` style. Usage is suppressed for runtime errors via `SilenceUsage`.
- `esp --help` continues to work without AWS env vars (cobra short-circuits before `PersistentPreRunE`, same as it did before `OnInitialize`).

## Test Plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages report `ok` or `[no test files]`
- [x] `esp --help` prints usage with no AWS env vars set, exit 0
- [x] `esp version` with no `AWS_DEFAULT_REGION` → `Error: AWS_DEFAULT_REGION environment variable is not set`, exit 1
- [x] `esp version` with `AWS_DEFAULT_REGION` set but no `AWS_PROFILE` → `Error: AWS_PROFILE environment variable is not set`, exit 1
- [ ] Smoke test against a real AWS account (reviewer)