### PR TITLE
Pure-logic unit tests (PR 2 of 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,4 +55,8 @@ Implement the `client.Client` interface (`internal/client/client.go`) in a new p
 
 ## Testing notes
 
-`cmd/get_test.go`, `cmd/put_test.go`, `internal/app/config_test.go`, and `internal/client/client_test.go` are empty stub files (package declaration only) — they exist to satisfy the test runner in forks. Real tests live in `cmd/list_test.go` and `internal/app/init_test.go`.
+Tests use stdlib `testing` only (no testify). Table-driven where the function has multiple distinct cases. One `_test.go` file per package, alongside the file under test. The bar is: every pure function reachable from a subcommand has a happy-path test plus its meaningful edge cases.
+
+Functions that exist only for side effects against AWS — `Service.Save` / `GetOne` / `GetMany` / `Copy` / `Delete`, the `EspClient` wrappers in `internal/client/`, and `Service.Init` — are intentionally not unit-tested. Exercising them requires either real AWS credentials or a dependency-injection seam that doesn't exist yet. The `client.New` test (`internal/client/client_test.go`) covers only the unsupported-backend path for that reason.
+
+The `cmd` package shares two package-level globals (`esp *app.Config` and `c *client.EspClient`) across subcommands. Tests that depend on them use the local `withOrgPrefix` and `withAppConfig` helpers in `cmd/put_test.go` and `cmd/get_test.go` to swap values in and restore them via `t.Cleanup`.

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,1 +1,68 @@
 package cmd
+
+import (
+	"testing"
+
+	"github.com/pinpt/esp/internal/app"
+)
+
+// withAppConfig swaps in a test app.Config on the package-level esp
+// global and restores the previous value when the test finishes.
+// getParamPath delegates to esp.GetAppParamPath, which depends on
+// these fields.
+func withAppConfig(t *testing.T, cfg app.Config) {
+	t.Helper()
+	prev := esp
+	cfg.Filename = ".espFile"
+	cfg.Path = ""
+	scoped := cfg
+	esp = &scoped
+	t.Cleanup(func() { esp = prev })
+}
+
+// TestGetParamPath pins getParamPath's rule: a leading "/" means the
+// caller already wrote a literal SSM path, so it passes through; any
+// other shape is routed through esp.GetAppParamPath.
+func TestGetParamPath(t *testing.T) {
+	withAppConfig(t, app.Config{
+		OrgName: "acme",
+		Env:     "dev",
+		AppName: "billing",
+	})
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "leading slash → literal path returned unchanged",
+			in:   "/acme/dev/billing/DB_URL",
+			want: "/acme/dev/billing/DB_URL",
+		},
+		{
+			name: "absolute path with different segments → unchanged",
+			in:   "/some/other/place",
+			want: "/some/other/place",
+		},
+		{
+			name: "short name → resolved through GetAppParamPath",
+			in:   "DB_URL",
+			want: "/acme/dev/billing/DB_URL",
+		},
+		{
+			name: "lowercase short name passes through verbatim (no upcasing here)",
+			in:   "secret",
+			want: "/acme/dev/billing/secret",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getParamPath(tc.in)
+			if got != tc.want {
+				t.Errorf("getParamPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/pinpt/esp/internal/app"
+)
 
 func TestGetPathWithFullPath(t *testing.T) {
 	testPath := "/corpa/dev/foo_app/"
@@ -15,5 +19,22 @@ func TestGetPathEnvVarName(t *testing.T) {
 	path := getPath([]string{envVar})
 	if path != envVar {
 		t.Errorf("want: %s | got %s", envVar, path)
+	}
+}
+
+// TestGetPathRelative pins getPath's empty-args branch: no positional
+// argument means "list the project's base path", which is built from
+// esp.GetAppPath() and follows the /OrgName/Env/AppName/ convention.
+func TestGetPathRelative(t *testing.T) {
+	withAppConfig(t, app.Config{
+		OrgName: "acme",
+		Env:     "dev",
+		AppName: "billing",
+	})
+
+	got := getPath(nil)
+	want := "/acme/dev/billing/"
+	if got != want {
+		t.Errorf("getPath(nil) = %q, want %q", got, want)
 	}
 }

--- a/cmd/put_test.go
+++ b/cmd/put_test.go
@@ -1,1 +1,78 @@
 package cmd
+
+import (
+	"testing"
+
+	"github.com/pinpt/esp/internal/app"
+)
+
+// withOrgPrefix swaps in a test OrgPrefix on the package-level esp
+// config and restores the previous value when the test finishes.
+// formatParamName depends on this global; resetting prevents test
+// pollution across the cmd package.
+func withOrgPrefix(t *testing.T, prefix string) {
+	t.Helper()
+	if esp == nil {
+		esp = app.New(false)
+	}
+	prev := esp.OrgPrefix
+	esp.OrgPrefix = prefix
+	t.Cleanup(func() { esp.OrgPrefix = prev })
+}
+
+// TestEspName pins formatParamName's actual rule:
+//
+//	if HasPrefix(n, OrgPrefix) -> n unchanged
+//	else                       -> OrgPrefix + "_" + ToUpper(n)
+//
+// Hyphens are NOT converted to underscores; ToUpper is the only
+// transform applied.
+func TestEspName(t *testing.T) {
+	withOrgPrefix(t, "ACME")
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "already prefixed (canonical) is unchanged",
+			in:   "ACME_FOO",
+			want: "ACME_FOO",
+		},
+		{
+			name: "lowercase input is uppercased and prefixed",
+			in:   "foo",
+			want: "ACME_FOO",
+		},
+		{
+			name: "hyphenated input is uppercased; hyphens are preserved (not converted to underscores)",
+			in:   "foo-bar",
+			want: "ACME_FOO-BAR",
+		},
+		{
+			name: "mixed case input is fully uppercased",
+			in:   "fooBar",
+			want: "ACME_FOOBAR",
+		},
+		{
+			name: "any string starting with the prefix passes through unchanged (HasPrefix, not exact match)",
+			in:   "ACMEISH",
+			want: "ACMEISH",
+		},
+		{
+			name: "uppercase non-prefixed input still gets prefix",
+			in:   "FOO",
+			want: "ACME_FOO",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatParamName(tc.in)
+			if got != tc.want {
+				t.Errorf("formatParamName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,1 +1,108 @@
 package app
+
+import "testing"
+
+func TestGetAppPath(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "all fields populated",
+			cfg:  Config{OrgName: "acme", Env: "dev", AppName: "billing"},
+			want: "/acme/dev/billing/",
+		},
+		{
+			name: "single-letter fields",
+			cfg:  Config{OrgName: "a", Env: "b", AppName: "c"},
+			want: "/a/b/c/",
+		},
+		{
+			name: "empty fields produce empty segments",
+			cfg:  Config{},
+			want: "////",
+		},
+		{
+			name: "only OrgName set",
+			cfg:  Config{OrgName: "acme"},
+			want: "/acme///",
+		},
+		{
+			name: "leading slashes in inputs are not stripped",
+			cfg:  Config{OrgName: "/acme", Env: "/dev", AppName: "/billing"},
+			want: "//acme//dev//billing/",
+		},
+		{
+			name: "names with hyphens and underscores pass through",
+			cfg:  Config{OrgName: "acme-corp", Env: "prod", AppName: "billing_svc"},
+			want: "/acme-corp/prod/billing_svc/",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.cfg.GetAppPath()
+			if got != tc.want {
+				t.Errorf("GetAppPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetAppParamPath(t *testing.T) {
+	base := Config{OrgName: "acme", Env: "dev", AppName: "billing"}
+
+	tests := []struct {
+		name  string
+		cfg   Config
+		param string
+		want  string
+	}{
+		{
+			name:  "simple param",
+			cfg:   base,
+			param: "DB_URL",
+			want:  "/acme/dev/billing/DB_URL",
+		},
+		{
+			name:  "lowercase param",
+			cfg:   base,
+			param: "secret",
+			want:  "/acme/dev/billing/secret",
+		},
+		{
+			name:  "empty param leaves trailing slash",
+			cfg:   base,
+			param: "",
+			want:  "/acme/dev/billing/",
+		},
+		{
+			name:  "leading slash on param produces double slash",
+			cfg:   base,
+			param: "/DB_URL",
+			want:  "/acme/dev/billing//DB_URL",
+		},
+		{
+			name:  "param containing slashes pass through",
+			cfg:   base,
+			param: "nested/key/name",
+			want:  "/acme/dev/billing/nested/key/name",
+		},
+		{
+			name:  "all-empty config with param",
+			cfg:   Config{},
+			param: "X",
+			want:  "////X",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.cfg.GetAppParamPath(tc.param)
+			if got != tc.want {
+				t.Errorf("GetAppParamPath(%q) = %q, want %q", tc.param, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/app/init_test.go
+++ b/internal/app/init_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -75,5 +76,112 @@ func TestWriteConfig(t *testing.T) {
 
 	if !checkEspFile(actualEsp, testEsp) {
 		t.Errorf("The written config didn't match the test input")
+	}
+}
+
+func TestUpdateWithInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		envs     string
+		wantEnvs []string
+	}{
+		{
+			name:     "no whitespace",
+			envs:     "dev,test,prod",
+			wantEnvs: []string{"dev", "test", "prod"},
+		},
+		{
+			name:     "single trailing space after each comma",
+			envs:     "dev, test, prod",
+			wantEnvs: []string{"dev", "test", "prod"},
+		},
+		{
+			name:     "multiple trailing spaces after each comma",
+			envs:     "dev,   test,  prod",
+			wantEnvs: []string{"dev", "test", "prod"},
+		},
+		{
+			name:     "single env",
+			envs:     "dev",
+			wantEnvs: []string{"dev"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Config{}
+			c.UpdateWithInput(configInput{
+				Backend:   "ssm",
+				OrgName:   "acme",
+				OrgPrefix: "ACME",
+				AppName:   "billing",
+				Envs:      tc.envs,
+			})
+			if c.Backend != "ssm" || c.OrgName != "acme" || c.OrgPrefix != "ACME" || c.AppName != "billing" {
+				t.Errorf("scalar fields not copied: got %+v", c)
+			}
+			if !reflect.DeepEqual(c.Envs, tc.wantEnvs) {
+				t.Errorf("Envs = %#v, want %#v", c.Envs, tc.wantEnvs)
+			}
+		})
+	}
+}
+
+func TestCreateEspFile(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want espFile
+	}{
+		{
+			name: "fully populated",
+			cfg: Config{
+				Backend:   "ssm",
+				OrgName:   "acme",
+				OrgPrefix: "ACME",
+				AppName:   "billing",
+				Envs:      []string{"dev", "test", "prod"},
+			},
+			want: espFile{
+				Backend:   "ssm",
+				OrgName:   "acme",
+				OrgPrefix: "ACME",
+				AppName:   "billing",
+				Envs:      []string{"dev", "test", "prod"},
+			},
+		},
+		{
+			name: "zero value Config produces zero value espFile",
+			cfg:  Config{},
+			want: espFile{},
+		},
+		{
+			name: "non-espFile fields on Config are not copied",
+			cfg: Config{
+				Backend:      "ssm",
+				OrgName:      "acme",
+				AppName:      "billing",
+				Envs:         []string{"dev"},
+				IsEspProject: true,
+				Env:          "dev",
+				Path:         "/tmp/somewhere",
+				Filename:     ".espFile",
+			},
+			want: espFile{
+				Backend: "ssm",
+				OrgName: "acme",
+				AppName: "billing",
+				Envs:    []string{"dev"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.cfg.createEspFile()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("createEspFile() = %#v, want %#v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,1 +1,32 @@
 package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pinpt/esp/internal/app"
+)
+
+// TestNewUnsupportedBackend covers the only branch of client.New
+// reachable without AWS credentials: an unsupported Backend value
+// must return a non-nil error and a nil EspClient.
+//
+// The "ssm" happy path is not tested here. It calls
+// config.LoadDefaultConfig, which would either reach out to the
+// environment for AWS credentials or fail with MissingRegion — both
+// of which make the test environment-dependent. Exercising it
+// requires either a dependency-injection seam or an integration
+// harness, both deferred to future work (see the cleanup-and-tests
+// design doc, "Non-Goals").
+func TestNewUnsupportedBackend(t *testing.T) {
+	c, err := New(&app.Config{Backend: "vault"})
+	if err == nil {
+		t.Fatalf("New with unsupported backend returned nil error; want error, got client = %#v", c)
+	}
+	if c != nil {
+		t.Errorf("New with unsupported backend returned non-nil client = %#v; want nil", c)
+	}
+	if !strings.Contains(err.Error(), "vault") {
+		t.Errorf("error message %q does not mention the offending backend %q", err.Error(), "vault")
+	}
+}

--- a/internal/ssm/errors_test.go
+++ b/internal/ssm/errors_test.go
@@ -1,0 +1,223 @@
+package ssm
+
+import (
+	"errors"
+	"testing"
+
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/smithy-go"
+)
+
+// genericAPIErr returns a *smithy.GenericAPIError (which satisfies
+// smithy.APIError) for use in fallthrough cases.
+func genericAPIErr() error {
+	return &smithy.GenericAPIError{Code: "Unknown", Message: "unknown api failure"}
+}
+
+// plainErr returns a non-API error to verify the no-match-returns-nil path.
+func plainErr() error { return errors.New("plain non-api error") }
+
+func TestCheckBaseSSMErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantSelf  bool // expect the function to return err unchanged
+		wantNil   bool // expect nil
+	}{
+		{name: "InvalidKeyId is mapped", err: &ssmtypes.InvalidKeyId{}, wantSelf: true},
+		{name: "InternalServerError is mapped", err: &ssmtypes.InternalServerError{}, wantSelf: true},
+		{name: "generic smithy.APIError falls through and is returned", err: genericAPIErr(), wantSelf: true},
+		{name: "plain non-API error returns nil", err: plainErr(), wantNil: true},
+		{name: "nil input returns nil", err: nil, wantNil: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkBaseSSMErrors(tc.err)
+			if tc.wantSelf && got != tc.err {
+				t.Errorf("checkBaseSSMErrors(%v) = %v, want input err returned", tc.err, got)
+			}
+			if tc.wantNil && got != nil {
+				t.Errorf("checkBaseSSMErrors(%v) = %v, want nil", tc.err, got)
+			}
+		})
+	}
+}
+
+func TestCheckSSMGetParameterError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantSelf bool
+		wantNil  bool
+	}{
+		{name: "ParameterNotFound is mapped", err: &ssmtypes.ParameterNotFound{}, wantSelf: true},
+		{name: "generic smithy.APIError falls through and is returned", err: genericAPIErr(), wantSelf: true},
+		{name: "plain non-API error returns nil", err: plainErr(), wantNil: true},
+		{name: "nil input returns nil", err: nil, wantNil: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkSSMGetParameterError(tc.err)
+			if tc.wantSelf && got != tc.err {
+				t.Errorf("checkSSMGetParameterError(%v) = %v, want input err returned", tc.err, got)
+			}
+			if tc.wantNil && got != nil {
+				t.Errorf("checkSSMGetParameterError(%v) = %v, want nil", tc.err, got)
+			}
+		})
+	}
+}
+
+func TestCheckSSMPutParameterError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantSelf bool
+		wantNil  bool
+	}{
+		{name: "ParameterLimitExceeded", err: &ssmtypes.ParameterLimitExceeded{}, wantSelf: true},
+		{name: "TooManyUpdates", err: &ssmtypes.TooManyUpdates{}, wantSelf: true},
+		{name: "HierarchyTypeMismatchException", err: &ssmtypes.HierarchyTypeMismatchException{}, wantSelf: true},
+		{name: "InvalidAllowedPatternException", err: &ssmtypes.InvalidAllowedPatternException{}, wantSelf: true},
+		{name: "ParameterMaxVersionLimitExceeded", err: &ssmtypes.ParameterMaxVersionLimitExceeded{}, wantSelf: true},
+		{name: "UnsupportedParameterType", err: &ssmtypes.UnsupportedParameterType{}, wantSelf: true},
+		{name: "PoliciesLimitExceededException", err: &ssmtypes.PoliciesLimitExceededException{}, wantSelf: true},
+		{name: "InvalidPolicyTypeException", err: &ssmtypes.InvalidPolicyTypeException{}, wantSelf: true},
+		{name: "InvalidPolicyAttributeException", err: &ssmtypes.InvalidPolicyAttributeException{}, wantSelf: true},
+		{name: "IncompatiblePolicyException", err: &ssmtypes.IncompatiblePolicyException{}, wantSelf: true},
+		{name: "ParameterAlreadyExists", err: &ssmtypes.ParameterAlreadyExists{}, wantSelf: true},
+		{name: "generic smithy.APIError falls through", err: genericAPIErr(), wantSelf: true},
+		{name: "plain non-API error returns nil", err: plainErr(), wantNil: true},
+		{name: "nil input returns nil", err: nil, wantNil: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkSSMPutParameterError(tc.err)
+			if tc.wantSelf && got != tc.err {
+				t.Errorf("checkSSMPutParameterError(%v) = %v, want input err returned", tc.err, got)
+			}
+			if tc.wantNil && got != nil {
+				t.Errorf("checkSSMPutParameterError(%v) = %v, want nil", tc.err, got)
+			}
+		})
+	}
+}
+
+func TestCheckDeleteParameterError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantSelf bool
+		wantNil  bool
+	}{
+		{name: "ParameterNotFound is mapped", err: &ssmtypes.ParameterNotFound{}, wantSelf: true},
+		{name: "generic smithy.APIError falls through", err: genericAPIErr(), wantSelf: true},
+		{name: "plain non-API error returns nil", err: plainErr(), wantNil: true},
+		{name: "nil input returns nil", err: nil, wantNil: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkDeleteParameterError(tc.err)
+			if tc.wantSelf && got != tc.err {
+				t.Errorf("checkDeleteParameterError(%v) = %v, want input err returned", tc.err, got)
+			}
+			if tc.wantNil && got != nil {
+				t.Errorf("checkDeleteParameterError(%v) = %v, want nil", tc.err, got)
+			}
+		})
+	}
+}
+
+// checkSSMByPathError differs from the others: it does NOT have a
+// trailing smithy.APIError fallback, so a generic API error returns
+// nil rather than passing through. The test pins this asymmetry.
+func TestCheckSSMByPathError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantSelf bool
+		wantNil  bool
+	}{
+		{name: "InternalServerError", err: &ssmtypes.InternalServerError{}, wantSelf: true},
+		{name: "InvalidFilterKey", err: &ssmtypes.InvalidFilterKey{}, wantSelf: true},
+		{name: "InvalidFilterOption", err: &ssmtypes.InvalidFilterOption{}, wantSelf: true},
+		{name: "InvalidFilterValue", err: &ssmtypes.InvalidFilterValue{}, wantSelf: true},
+		{name: "InvalidKeyId", err: &ssmtypes.InvalidKeyId{}, wantSelf: true},
+		{name: "InvalidNextToken", err: &ssmtypes.InvalidNextToken{}, wantSelf: true},
+		{name: "generic smithy.APIError returns nil (no fallback in this function)", err: genericAPIErr(), wantNil: true},
+		{name: "plain non-API error returns nil", err: plainErr(), wantNil: true},
+		{name: "nil input returns nil", err: nil, wantNil: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkSSMByPathError(tc.err)
+			if tc.wantSelf && got != tc.err {
+				t.Errorf("checkSSMByPathError(%v) = %v, want input err returned", tc.err, got)
+			}
+			if tc.wantNil && got != nil {
+				t.Errorf("checkSSMByPathError(%v) = %v, want nil", tc.err, got)
+			}
+		})
+	}
+}
+
+// TestCheckSSMError exercises the dispatcher: each known action
+// routes to the matching per-action function; an unknown action
+// (e.g. GetMany, which has no case) falls through to checkBaseSSMErrors.
+func TestCheckSSMError(t *testing.T) {
+	tests := []struct {
+		name     string
+		action   action
+		err      error
+		wantSelf bool
+		wantNil  bool
+	}{
+		{
+			name:     "Get routes to checkSSMGetParameterError",
+			action:   Get,
+			err:      &ssmtypes.ParameterNotFound{},
+			wantSelf: true,
+		},
+		{
+			name:     "Save routes to checkSSMPutParameterError",
+			action:   Save,
+			err:      &ssmtypes.ParameterAlreadyExists{},
+			wantSelf: true,
+		},
+		{
+			name:     "Delete routes to checkDeleteParameterError",
+			action:   Delete,
+			err:      &ssmtypes.ParameterNotFound{},
+			wantSelf: true,
+		},
+		{
+			name:     "GetMany action falls through to base error mapper",
+			action:   GetMany,
+			err:      &ssmtypes.InternalServerError{},
+			wantSelf: true,
+		},
+		{
+			name:    "GetMany action with non-API error returns nil",
+			action:  GetMany,
+			err:     plainErr(),
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkSSMError(tc.action, tc.err)
+			if tc.wantSelf && got != tc.err {
+				t.Errorf("checkSSMError(%q, %v) = %v, want input err returned", tc.action, tc.err, got)
+			}
+			if tc.wantNil && got != nil {
+				t.Errorf("checkSSMError(%q, %v) = %v, want nil", tc.action, tc.err, got)
+			}
+		})
+	}
+}

--- a/internal/ssm/utils_test.go
+++ b/internal/ssm/utils_test.go
@@ -1,0 +1,104 @@
+package ssm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/pinpt/esp/internal/common"
+)
+
+func TestSelectType(t *testing.T) {
+	if got := selectType(true); got != ssmtypes.ParameterTypeSecureString {
+		t.Errorf("selectType(true) = %v, want %v", got, ssmtypes.ParameterTypeSecureString)
+	}
+	if got := selectType(false); got != ssmtypes.ParameterTypeString {
+		t.Errorf("selectType(false) = %v, want %v", got, ssmtypes.ParameterTypeString)
+	}
+}
+
+func TestConvertToEspParam(t *testing.T) {
+	modified := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		in   ssmtypes.Parameter
+		want common.EspParam
+	}{
+		{
+			name: "secure string sets Secure: true",
+			in: ssmtypes.Parameter{
+				ARN:              aws.String("arn:aws:ssm:us-east-1:1:parameter/acme/dev/billing/SECRET"),
+				Name:             aws.String("/acme/dev/billing/SECRET"),
+				Type:             ssmtypes.ParameterTypeSecureString,
+				Value:            aws.String("hunter2"),
+				Version:          7,
+				LastModifiedDate: aws.Time(modified),
+			},
+			want: common.EspParam{
+				Id:               "arn:aws:ssm:us-east-1:1:parameter/acme/dev/billing/SECRET",
+				Name:             "/acme/dev/billing/SECRET",
+				Type:             "SecureString",
+				Value:            "hunter2",
+				Version:          7,
+				LastModifiedDate: modified,
+				Secure:           true,
+			},
+		},
+		{
+			name: "plain string leaves Secure: false",
+			in: ssmtypes.Parameter{
+				ARN:              aws.String("arn:plain"),
+				Name:             aws.String("DB_URL"),
+				Type:             ssmtypes.ParameterTypeString,
+				Value:            aws.String("postgres://"),
+				Version:          1,
+				LastModifiedDate: aws.Time(modified),
+			},
+			want: common.EspParam{
+				Id:               "arn:plain",
+				Name:             "DB_URL",
+				Type:             "String",
+				Value:            "postgres://",
+				Version:          1,
+				LastModifiedDate: modified,
+				Secure:           false,
+			},
+		},
+		{
+			name: "stringlist leaves Secure: false (only SecureString flips it)",
+			in: ssmtypes.Parameter{
+				ARN:   aws.String("arn:list"),
+				Name:  aws.String("LIST"),
+				Type:  ssmtypes.ParameterTypeStringList,
+				Value: aws.String("a,b,c"),
+			},
+			want: common.EspParam{
+				Id:     "arn:list",
+				Name:   "LIST",
+				Type:   "StringList",
+				Value:  "a,b,c",
+				Secure: false,
+			},
+		},
+		{
+			name: "nil pointer fields render as zero values via aws.ToString / aws.ToTime",
+			in: ssmtypes.Parameter{
+				Type: ssmtypes.ParameterTypeString,
+			},
+			want: common.EspParam{
+				Type: "String",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := convertToEspParam(tc.in)
+			if got != tc.want {
+				t.Errorf("convertToEspParam(%+v) =\n  %+v\nwant\n  %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements PR 2 of the cleanup-and-tests design (`docs/superpowers/specs/2026-05-05-cleanup-and-tests-design.md`). All test files use stdlib `testing` only, table-driven where the function has multiple distinct cases. No production code changes.

Builds on the cleaner shape from PR 1 (#26).

## Commits (in order)

1. `test: cover internal/app path builders and init` — `TestGetAppPath` and `TestGetAppParamPath` lock down the `/OrgName/Env/AppName/[param]` convention and edge cases (empty fields, leading slashes in inputs, slash-containing param names). `TestUpdateWithInput` pins the comma-list `regexp.MustCompile(", *").Split` rule. `TestCreateEspFile` asserts which fields cross from `Config` to `espFile` and which don't.
2. `test: cover cmd path/name helpers` — `TestEspName` (the spec name; tests `formatParamName`) pins the actual rule: `HasPrefix → unchanged`, else `OrgPrefix + "_" + ToUpper(n)`. **Hyphens are preserved, not converted to underscores** — this surfaces a behavior the design doc described differently; the test pins what the code actually does. `TestGetParamPath` covers the slash-prefix vs. short-name routing in `cmd/get.go`. `TestGetPathRelative` covers the empty-args branch of `getPath` in `cmd/list.go`. Adds `withOrgPrefix` / `withAppConfig` helpers to swap the package-level globals in and out per test.
3. `test: cover internal/ssm utils and errors` — `TestSelectType` and `TestConvertToEspParam` (including `Secure: true` flip on `SecureString`). One test per `checkSSM*Error` function plus the dispatcher; each covers typed-error pass-through, the `smithy.APIError` fallback, and the `nil` no-match path. **`TestCheckSSMByPathError` pins the asymmetry that this function has no `smithy.APIError` fallback** — generic API errors return `nil`, unlike its siblings.
4. `test: cover internal/client.New unsupported-backend path` — `TestNewUnsupportedBackend` confirms a non-`"ssm"` backend returns `(nil, error)` with the offending backend named in the message. The `"ssm"` happy path is intentionally not covered (would require AWS credentials or a DI seam — explicitly deferred per the spec's Non-Goals).
5. `chore: refresh CLAUDE.md testing notes` — replaces the stale "these four files are empty stubs" paragraph (all four are now populated) with the actual test conventions used in this PR.

## Behavior pinned by the new tests (worth a second look)

- `formatParamName` does **not** convert hyphens to underscores; only `ToUpper`. The spec asked for "hyphens to underscores" but the code preserves hyphens — `TestEspName/hyphenated_input...` makes this explicit.
- `getPath` (cmd/list.go) returns the positional arg verbatim for any non-empty input; only the empty-args branch routes through `GetAppPath()`. `TestGetPathEnvVarName` already documented this; `TestGetPathRelative` adds the empty-args side.
- `checkSSMByPathError` has no `smithy.APIError` fallback. A generic API error from a `GetParametersByPath` call would return `nil` from this mapper, which is then handled by `mapErr`'s raw-error fallback — so callers still see the failure. Worth knowing if the dispatch in `checkSSMError` ever wires `GetMany` to use it.

## Spec deviations

- The design doc's commit 5 was conditional ("delete unused stub test files (only if the audit during PR 2 finds any)"). All four stubs are populated by commits 1–4, so nothing to delete. The slot is repurposed for the CLAUDE.md docs refresh.

## Test Plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — every package now reports `ok` (was several `[no test files]`)
- [x] No production code modified — git log shows test/docs commits only