### PR TITLE
Fix two behaviors PR 2's tests pinned as quirks

### DIFF
--- a/cmd/put.go
+++ b/cmd/put.go
@@ -12,7 +12,11 @@ func formatParamName(n string) string {
 	if strings.HasPrefix(n, esp.OrgPrefix) {
 		return n
 	}
-	return esp.OrgPrefix + "_" + strings.ToUpper(n)
+	// SSM allows hyphens in parameter names, but esp's purpose is to
+	// surface params as environment variables, where hyphens are not
+	// valid. Normalize them to underscores alongside the upcasing.
+	normalized := strings.ReplaceAll(strings.ToUpper(n), "-", "_")
+	return esp.OrgPrefix + "_" + normalized
 }
 
 func getFullPath(n string) string {

--- a/cmd/put_test.go
+++ b/cmd/put_test.go
@@ -20,13 +20,13 @@ func withOrgPrefix(t *testing.T, prefix string) {
 	t.Cleanup(func() { esp.OrgPrefix = prev })
 }
 
-// TestEspName pins formatParamName's actual rule:
+// TestEspName pins formatParamName's rule:
 //
 //	if HasPrefix(n, OrgPrefix) -> n unchanged
-//	else                       -> OrgPrefix + "_" + ToUpper(n)
+//	else                       -> OrgPrefix + "_" + ReplaceAll(ToUpper(n), "-", "_")
 //
-// Hyphens are NOT converted to underscores; ToUpper is the only
-// transform applied.
+// Hyphens are normalized to underscores so the resulting name is a
+// valid environment variable identifier.
 func TestEspName(t *testing.T) {
 	withOrgPrefix(t, "ACME")
 
@@ -46,9 +46,14 @@ func TestEspName(t *testing.T) {
 			want: "ACME_FOO",
 		},
 		{
-			name: "hyphenated input is uppercased; hyphens are preserved (not converted to underscores)",
+			name: "hyphenated input is uppercased and hyphens become underscores",
 			in:   "foo-bar",
-			want: "ACME_FOO-BAR",
+			want: "ACME_FOO_BAR",
+		},
+		{
+			name: "multiple hyphens all convert to underscores",
+			in:   "foo-bar-baz",
+			want: "ACME_FOO_BAR_BAZ",
 		},
 		{
 			name: "mixed case input is fully uppercased",
@@ -64,6 +69,11 @@ func TestEspName(t *testing.T) {
 			name: "uppercase non-prefixed input still gets prefix",
 			in:   "FOO",
 			want: "ACME_FOO",
+		},
+		{
+			name: "already-prefixed input keeps its hyphens (HasPrefix branch returns verbatim)",
+			in:   "ACME-LEGACY-NAME",
+			want: "ACME-LEGACY-NAME",
 		},
 	}
 

--- a/internal/ssm/errors.go
+++ b/internal/ssm/errors.go
@@ -143,5 +143,9 @@ func checkSSMByPathError(err error) error {
 	if errors.As(err, &invalidNextToken) {
 		return err
 	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return err
+	}
 	return nil
 }

--- a/internal/ssm/errors_test.go
+++ b/internal/ssm/errors_test.go
@@ -132,9 +132,6 @@ func TestCheckDeleteParameterError(t *testing.T) {
 	}
 }
 
-// checkSSMByPathError differs from the others: it does NOT have a
-// trailing smithy.APIError fallback, so a generic API error returns
-// nil rather than passing through. The test pins this asymmetry.
 func TestCheckSSMByPathError(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -148,7 +145,7 @@ func TestCheckSSMByPathError(t *testing.T) {
 		{name: "InvalidFilterValue", err: &ssmtypes.InvalidFilterValue{}, wantSelf: true},
 		{name: "InvalidKeyId", err: &ssmtypes.InvalidKeyId{}, wantSelf: true},
 		{name: "InvalidNextToken", err: &ssmtypes.InvalidNextToken{}, wantSelf: true},
-		{name: "generic smithy.APIError returns nil (no fallback in this function)", err: genericAPIErr(), wantNil: true},
+		{name: "generic smithy.APIError falls through and is returned", err: genericAPIErr(), wantSelf: true},
 		{name: "plain non-API error returns nil", err: plainErr(), wantNil: true},
 		{name: "nil input returns nil", err: nil, wantNil: true},
 	}


### PR DESCRIPTION
## Summary

Stacked on #27. Fixes the two behaviors PR 2 flagged as "notable items pinned by the new tests":

1. **`formatParamName` now converts hyphens to underscores.** esp's purpose is to expose SSM params as environment variables; env var names cannot contain hyphens. The function already uppercased un-prefixed names — extending the same step to replace hyphens makes the output a valid identifier. `esp put -n my-app-key -v ...` now produces `ACME_MY_APP_KEY` instead of the half-normalized `ACME_MY-APP-KEY`. The `HasPrefix` branch is unchanged: callers passing a fully-formed name keep it verbatim.
2. **`checkSSMByPathError` now has the `smithy.APIError` fallback its siblings already have.** Previously this was the only mapper missing the trailing generic-API catch, so any `GetParametersByPath` failure outside the explicit list (throttling, auth, region issues) mapped to `nil` and would be silently swallowed by callers using this mapper. The dispatcher does not currently route `GetMany` here, so today this is defensive — but the function is shaped to be reused, and any future caller would have inherited the swallow bug.

Both behaviors were the design doc's stated intent; the code shipped without them. Tests added in #27 are updated in lockstep — the assertion that previously read "hyphens preserved" now reads "hyphens become underscores", and the assertion that read "no fallback in this function" now reads "falls through and is returned".

## Stacking

PR base is `feature/tests-pure-logic` (#27). After #27 merges, GitHub will automatically retarget the base of this PR to `main`.

## Test Plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass; the two updated table cases now assert the new behavior

## Commits

1. `fix(cmd/put): normalize hyphens to underscores in formatParamName`
2. `fix(internal/ssm): add smithy.APIError fallback to checkSSMByPathError`